### PR TITLE
[REFACTOR] Rename Submodule `wrappers` to `pydry` for Easy Understanding

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,7 +5,7 @@
 	path = modules/utils/dtutils
 	url = https://gist.github.com/ZenithClown/d2dd294c5f528459e16b139c04c0b182.git
 [submodule "modules/customize/wrappers"]
-	path = modules/customize/wrappers
+	path = modules/customize/pydry
 	url = https://gist.github.com/ZenithClown/df4391a8b0313eb808e9a0f4ef5c78ad.git
 [submodule "modules/customize/prettyprint"]
 	path = modules/customize/prettyprint

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,7 @@ import sys
 # ? insert the project paths to let sphinx recognize/find packages
 sys.path.append(os.path.abspath(os.path.join("..", "modules", "utils", "dtutils")))
 sys.path.append(os.path.abspath(os.path.join("..", "modules", "utils", "sqlutils")))
-sys.path.append(os.path.abspath(os.path.join("..", "modules", "customize", "wrappers")))
+sys.path.append(os.path.abspath(os.path.join("..", "modules", "customize", "pydry")))
 sys.path.append(os.path.abspath(os.path.join("..", "modules", "customize", "prettyprint")))
 
 project = "DS Gringotts"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,6 +25,7 @@ import prettify # noqa: F401, F403 # pyright: ignore[reportMissingImports]
 import pwrapper # noqa: F401, F403 # pyright: ignore[reportMissingImports]
 import sqlparser # noqa: F401, F403 # pyright: ignore[reportMissingImports]
 import timer_decorator # noqa: F401, F403 # pyright: ignore[reportMissingImports]
+import context_manager # noqa: F401, F403 # pyright: ignore[reportMissingImports]
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration


### PR DESCRIPTION
<!--
Thanks for Creating a Pull Requests (PRs) 😃

Please make sure that the PR is limited to only ONE type (docs, features, etc.), and keep it as small as possible.
You can open multiple PRs if need be! Below, mentioned are the basic requirements and checks that are required
for the PR to be accepted and merged into the `master` branch.
-->

## :scroll: Description
[NOTE]: # ( Give a BRIEF description about the PR )
[NOTE]: # ( Please, also include relevant motivation and/or context )
[NOTE]: # ( List any dependencies, that are required for this change )
The module `wrappers` does not capture the full context of the usability of the module, thus rename the module to `pydry` which stands for "Python's DRY Tools" principal adoption related functions.

[NOTE]: # ( Please mention the type of change that will occur with this PR )
[NOTE]: # ( Generally, change is one of the following types, choose the correct one, and delete the rest )
This PR brings the following change(s):

* :hammer_and_wrench: **Breaking Change** - breaks existing submodule referencing `wrappers` module.
* :book: **Documentation Change** - updates docs related to the changes, and adds new functionalities.

The PR is dependent on #29 to be merged first.